### PR TITLE
Adding generated weights and biases training run files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# weights and biases training run files
+wandb/


### PR DESCRIPTION
Weights and biases generates a lot of files locally that are clutter for the repo and should be ignored. I've added a line to .gitignore to address this.